### PR TITLE
chore: add lint fixes, golangci-lint CI wiring, and goreleaser config

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,8 +9,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
+      # - name: Unshallow clone for tags
+      #   run: git fetch --prune --unshallow --tags
       - name: Install Go
         uses: actions/setup-go@v6
         with:
@@ -40,5 +40,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v2.1.0
         with:
           repo: pulumi/pulumictl
+      - name: Lint
+        run: task lint
       - name: build sdk
         run: task build_sdks

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,8 +9,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-      # - name: Unshallow clone for tags
-      #   run: git fetch --prune --unshallow --tags
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
       - name: Install Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -41,6 +41,10 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+      - name: Lint
         run: task lint
       - name: build sdk
         run: task build_sdks

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,51 @@
+version: "2"
+
+linters:
+  enable:
+    - goconst
+    - gosec
+    - lll
+    - misspell
+    - modernize
+    - nakedret
+    - revive
+    - staticcheck
+    - unconvert
+    - usetesting
+  settings:
+    lll:
+      line-length: 160
+    usetesting:
+      os-temp-dir: true
+      context-background: true
+      context-todo: true
+    revive:
+      rules:
+        - name: package-comments
+          exclude:
+            - '**/internal/**'
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - goconst
+          - lll
+        path: "_test\\.go"
+      - linters:
+          - gosec
+        text: "G101"
+        path: "_test\\.go"
+    paths:
+      - vendor$
+      - third_party$
+      - testdata$
+
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - vendor$
+      - third_party$
+      - testdata$

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,65 @@
+version: 2
+
+project_name: pulumi-nat
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: pulumi-resource-nat
+    main: .
+    binary: pulumi-resource-nat
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - id: pulumi-resource-nat
+    ids:
+      - pulumi-resource-nat
+    name_template: "pulumi-resource-nat-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    formats: ["tar.gz"]
+    format_overrides:
+      - goos: windows
+        formats: ["zip"]
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "^ci:"
+      - "^build:"
+      - "^style:"
+      - "^refactor:"
+      - Merge pull request
+      - Merge branch
+  groups:
+    - title: "New Features"
+      regexp: "^feat"
+      order: 0
+    - title: "Bug Fixes"
+      regexp: "^fix"
+      order: 1
+    - title: "Other Changes"
+      order: 999
+
+release:
+  github:
+    owner: pierskarsenbarg
+    name: pulumi-nat
+  name_template: "{{ .Tag }}"
+  prerelease: auto

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+// Command pulumi-resource-nat is the entrypoint for the nat Pulumi provider.
 package main
 
 import (

--- a/pkg/account.go
+++ b/pkg/account.go
@@ -1,3 +1,4 @@
+// Package pkg implements the resources and components exposed by the nat provider.
 package pkg
 
 import (

--- a/pkg/fcknat.go
+++ b/pkg/fcknat.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/autoscaling"
@@ -64,7 +63,7 @@ func getSubnetIdsFromVpcId(vpcId string, ctx *pulumi.Context) ([]string, error) 
 }
 
 func getSubnetsFromRouteTableIds(routeTableIds []string, ctx *pulumi.Context) ([]string, error) {
-	routeTablesMap := make(map[string]interface{})
+	routeTablesMap := make(map[string]any)
 	var subnetIds []string
 	for _, id := range routeTableIds {
 		routeTable, err := ec2.LookupRouteTable(ctx, &ec2.LookupRouteTableArgs{
@@ -117,7 +116,7 @@ func (f *NatInstance) Construct(ctx *pulumi.Context, name, typ string, args NatI
 	})
 
 	vpcHasMultipleRoutes := pulumi.All(routeTableIds.Ids(), vpc.MainRouteTableId()).ApplyT(
-		func(args []interface{}) bool {
+		func(args []any) bool {
 			routeTblIds := args[0].([]string)
 			vpcMainRouteTableId := args[1].(string)
 			if len(routeTblIds) == 1 && vpcMainRouteTableId == routeTblIds[0] {
@@ -127,22 +126,18 @@ func (f *NatInstance) Construct(ctx *pulumi.Context, name, typ string, args NatI
 		})
 
 	subnetIds := pulumi.All(vpcHasMultipleRoutes, routeTableIds.Ids(), vpc.Id()).ApplyT(
-		func(args []interface{}) []string {
+		func(args []any) []string {
 			var subnetIds []string
 			multipleRoutes := args[0].(bool)
 			routeTbleIds := args[1].([]string)
 			if multipleRoutes {
 				subnetIds, _ = getSubnetsFromRouteTableIds(routeTbleIds, ctx)
-				sort.Slice(subnetIds, func(a, b int) bool {
-					return subnetIds[a] < subnetIds[b]
-				})
+				slices.Sort(subnetIds)
 			} else {
 				vpcId := args[2].(string)
 				subnetIds, _ = getSubnetIdsFromVpcId(vpcId, ctx)
 			}
-			sort.Slice(subnetIds, func(a, b int) bool {
-				return subnetIds[a] < subnetIds[b]
-			})
+			slices.Sort(subnetIds)
 			return subnetIds
 		}).(pulumi.StringArrayOutput)
 
@@ -266,7 +261,7 @@ func (f *NatInstance) Construct(ctx *pulumi.Context, name, typ string, args NatI
 		Owners: []string{
 			"568608671756",
 		},
-		MostRecent: pulumi.BoolRef(true),
+		MostRecent: new(true),
 		Filters: []ec2.GetAmiFilter{
 			{
 				Name: "name",

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -22,6 +22,9 @@ tasks:
     cmds:
       - go mod tidy
       - go build -o bin/{{.PROVIDER}} -ldflags "-X {{.PROJECT}}/{{.VERSION_PATH}}={{.VERSION}}"
+  lint:
+    cmds:
+      - golangci-lint run ./...
   get_schema:
     deps: [build_provider]
     cmds:


### PR DESCRIPTION
## Summary

Adds lint tooling and fixes to the provider, and a goreleaser config for release builds.

## Changes

- `pkg/fcknat.go`, `main.go`, `pkg/account.go`: fix golangci-lint findings (`interface{}` → `any`, `sort.Slice` → `slices.Sort`, `BoolRef(true)` → `new(true)`, missing package comments)
- `.golangci.yaml`: new lint config (modernize, revive, staticcheck, gosec, etc.)
- `taskfile.yaml`: add a `lint` task running `golangci-lint run ./...`
- `.github/workflows/pr.yaml`: run `task lint` and the `golangci-lint-action`, and re-enable the unshallow-clone step
- `.goreleaser.yml`: new goreleaser config to build/release the `pulumi-resource-nat` binary for linux/darwin/windows

## Test Plan

- [x] `task lint` reports 0 issues
- [x] `go build ./...` succeeds